### PR TITLE
Remove highlights from parameters and results output

### DIFF
--- a/llm_tools_exa.py
+++ b/llm_tools_exa.py
@@ -46,7 +46,6 @@ class ExaTools(llm.Toolbox):
             type="auto",
             include_domains=include_domains,
             text=True,
-            highlights=True,
         ).results
         output = []
         for result in results:
@@ -54,9 +53,6 @@ class ExaTools(llm.Toolbox):
             output.append(f"Author: {result.author}")
             output.append(f"URL: {result.url}")
             output.append(f"Published: {result.published_date}")
-            output.append("Highlights:")
-            for highlight in result.highlights:
-                output.append(f"- {highlight}")
             output.append(f"Text: {result.text}")
             output.append("---------\n")
         return "\n".join(output)


### PR DESCRIPTION
https://github.com/agno-agi/agno/issues/5272:

> @pixelsoccupied That's correct, the latest versions of the Exa SDK (exa-py 2.0.0 and above) have completely removed support for the highlights parameter:
>
>"The highlights feature has been completely removed from all SDKs. This feature was previously deprecated and is no longer available in the SDK packages."
>— Exa SDK Changelog, October 28, 2025 [Exa](https://docs.exa.ai/changelog/sdk-major-version-changes)
>
>Any usage or references to highlights should be removed from the codebase to avoid errors.

Otherwise we get this error:

```
Tool call: web_search({'query': 'example'})
  Error: Invalid option: 'highlights'
  Exception: Invalid option: 'highlights'
```

Verified locally that applying this diff fixes the Exa tools in `llm`.